### PR TITLE
doc: fix the setup long desc error

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -1,0 +1,1 @@
+the agent module of octopus

--- a/agent/setup.py
+++ b/agent/setup.py
@@ -24,6 +24,8 @@ setup(
     author="imotai",
     author_email="wangtaize@dbpunk.com",
     url="https://github.com/dbpunk-labs/octopus",
+    long_description= open('README.md').read(),
+    long_description_content_type='text/markdown',
     packages=[
         "octopus_agent",
     ],

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -1,17 +1,2 @@
-# The Kernel Server for Python Execution
+The Kernel Server for Python Execution
 
-## Run the Kernel Server
-
-```shell
-pip install .
-```
-
-## Request the Kernel Server
-
-```shell
-python3 -m websockets ws://127.0.0.1:9527
->  {"method":"start", "params":[], "id":0}
-< {"result": "ready", "id": 0}
-> {"method":"stop", "params":[], "id":1}
-< {"result": "stop", "id": 1}
-```

--- a/kernel/setup.py
+++ b/kernel/setup.py
@@ -24,6 +24,8 @@ setup(
     author="imotai",
     author_email="wangtaize@dbpunk.com",
     url="https://github.com/dbpunk-labs/octopus",
+    long_description= open('README.md').read(),
+    long_description_content_type='text/markdown',
     packages=[
         "octopus_kernel",
         "octopus_kernel.kernel",

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,12 +1,11 @@
-# The protobuf for octopus
 
-## Build
+the protobuf module of octopus
 
-install the grpc tools
+build the proto module
 ```
 pip install -r requirements.txt
 ```
-generate the python stubs
+generate the python stubs and  replace the module path
 ```
 make
 ```

--- a/proto/setup.py
+++ b/proto/setup.py
@@ -24,6 +24,8 @@ setup(
     author="imotai",
     author_email="wangtaize@dbpunk.com",
     url="https://github.com/dbpunk-labs/octopus",
+    long_description= open('README.md').read(),
+    long_description_content_type='text/markdown',
 
     packages=[
         "octopus_proto",
@@ -39,6 +41,8 @@ setup(
         "grpc-google-iam-v1>=0.12.6",
         "grpcio-tools>=1.57.0",
     ],
+
     entry_points={
     },
+
 )


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Updated `setup.py` files in `agent` and `kernel` directories to include `long_description` and `long_description_content_type` fields.
- Added `open('README.md').read()` as the value for `long_description` field in `setup.py` files.
- Added `long_description_content_type='text/markdown'` as the value for `long_description_content_type` field in `setup.py` files.
- Updated the `packages` field in `setup.py` files to include relevant packages.
- Updated the `proto/README.md` file to include information about building the protobuf module of octopus.
- Updated the `kernel/README.md` file to include information about running and requesting the Kernel Server for Python Execution.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->