### PR TITLE
fix: fix the chat module setup error

### DIFF
--- a/chat/setup.py
+++ b/chat/setup.py
@@ -24,6 +24,8 @@ setup(
     author="imotai",
     author_email="wangtaize@dbpunk.com",
     url="https://github.com/dbpunk-labs/octopus",
+    long_description= open('README.md').read(),
+    long_description_content_type='text/markdown',
     packages=[
         "octopus_discord",
         "octopus_terminal",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a long description to the setup.py file. 

### Detailed summary:
- Added `long_description` to setup.py.
- Set `long_description_content_type` to 'text/markdown'.
- Updated the list of packages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->