### PR TITLE
fix: use double quotes to resolve the image name error

### DIFF
--- a/.github/workflows/release_libraries.yml
+++ b/.github/workflows/release_libraries.yml
@@ -62,8 +62,8 @@ jobs:
           RELEASE_NAME=${GITHUB_REF/refs\/tags\//}
           cd ${ROOT_DIR}/docker && docker build -f Dockerfile --no-cache -t ghcr.io/dbpunk-labs/octopus_base:${RELEASE_NAME} .
           NEW_BASE_IMAGE="FROM ghcr.io/dbpunk-labs/octopus_base:${RELEASE_NAME}"
-          sed -i 's/FROM ghcr.io\/dbpunk-labs\/octopus_base/${NEW_BASE_IMAGE}/g' Dockerfile_for_agent
-          sed -i 's/FROM ghcr.io\/dbpunk-labs\/octopus_base/${NEW_BASE_IMAGE}/g' Dockerfile_for_kernel
+          sed -i "s/FROM ghcr.io\/dbpunk-labs\/octopus_base/${NEW_BASE_IMAGE}/g" Dockerfile_for_agent
+          sed -i "s/FROM ghcr.io\/dbpunk-labs\/octopus_base/${NEW_BASE_IMAGE}/g" Dockerfile_for_kernel
           docker build -f Dockerfile_for_agent --no-cache -t ghcr.io/dbpunk-labs/octopus_agent:${RELEASE_NAME} .
           docker build -f Dockerfile_for_kernel --no-cache -t ghcr.io/dbpunk-labs/octopus_kernel:${RELEASE_NAME} .
           docker push ghcr.io/dbpunk-labs/octopus_base:${RELEASE_NAME}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the base image for the Octopus agent and kernel Dockerfiles. 

### Detailed summary
- Updated the sed command to use double quotes instead of single quotes for string interpolation.
- Updated the Dockerfile_for_agent and Dockerfile_for_kernel to use the new base image.
- Rebuilt and pushed the updated Docker images to the registry.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->