### PR TITLE
fix: use has_error to show the result status

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,8 @@ jobs:
           pytest tests/*.py
           cd ${WS_DIR}/kernel
           pytest tests/*.py
+          cd ${WS_DIR}/chat
+          pytest tests/*.py
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/cli_ci.yaml
+++ b/.github/workflows/cli_ci.yaml
@@ -30,12 +30,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: pip install -r requirements.txt
+
       - name: Run cli tests
         shell: bash
         run: |
           cd up
-          pip install .
-          pytest tests/*.py
-          cd ../chat
           pip install .
           pytest tests/*.py

--- a/agent/src/og_agent/codellama_agent.py
+++ b/agent/src/og_agent/codellama_agent.py
@@ -248,7 +248,9 @@ class CodellamaAgent(BaseAgent):
                             respond_type=TaskRespond.OnAgentActionEndType,
                             model_name=model_name,
                             on_agent_action_end=OnAgentActionEnd(
-                                output="", output_files=function_result.saved_filenames
+                                output="",
+                                output_files=function_result.saved_filenames,
+                                has_error=function_result.has_error,
                             ),
                         )
                     )

--- a/agent/src/og_agent/mock_agent.py
+++ b/agent/src/og_agent/mock_agent.py
@@ -110,7 +110,9 @@ class MockAgent(BaseAgent):
                             respond_type=TaskRespond.OnAgentActionEndType,
                             model_name="mock model",
                             on_agent_action_end=OnAgentActionEnd(
-                                output="", output_files=function_result.saved_filenames
+                                output="",
+                                output_files=function_result.saved_filenames,
+                                has_error=function_result.has_error,
                             ),
                         )
                     )

--- a/agent/src/og_agent/openai_agent.py
+++ b/agent/src/og_agent/openai_agent.py
@@ -307,7 +307,9 @@ class OpenaiAgent(BaseAgent):
                             respond_type=TaskRespond.OnAgentActionEndType,
                             model_name=model_name,
                             on_agent_action_end=OnAgentActionEnd(
-                                output="", output_files=function_result.saved_filenames
+                                output="",
+                                output_files=function_result.saved_filenames,
+                                has_error=function_result.has_error,
                             ),
                         )
                     )

--- a/chat/src/og_terminal/terminal_chat.py
+++ b/chat/src/og_terminal/terminal_chat.py
@@ -195,23 +195,28 @@ def handle_action_output(segments, respond, values):
 
 
 def handle_action_end(segments, respond, images, values):
+    """
+    Handles the end of an agent action.
+
+    Args:
+      segments: A list of segments in the current turn.
+      respond: The response from the agent.
+      images: A list of images to be displayed.
+      values: A list of values to be copied
+
+    Returns:
+      None.
+    """
     if respond.respond_type != agent_server_pb2.TaskRespond.OnAgentActionEndType:
         return
     output = respond.on_agent_action_end.output
-    has_error = "✅"
+    has_error = "✅" if not respond.on_agent_action_end.has_error else "❌"
+    old_value = values.pop()
     segment = segments.pop()
-    mk = segment[2].code
-    # simple to handle error
-    if mk.find("Traceback") >= 0:
-        has_error = "❌"
-    syntax = Syntax(
-        mk,
-        "text",
-        line_numbers=True,  # background_color="default"
-    )
     if not images:
         images.extend(respond.on_agent_action_end.output_files)
-    segments.append((len(values) - 1, has_error, syntax))
+    segments.append((len(values) - 1, has_error, segment[2]))
+
     # add the next steps loading
     spinner = Spinner("dots", style="status.spinner", speed=1.0, text="")
     values.append(("text", "", []))

--- a/chat/src/og_terminal/terminal_chat.py
+++ b/chat/src/og_terminal/terminal_chat.py
@@ -186,10 +186,12 @@ def handle_action_output(segments, respond, values):
         new_stderr += respond.console_stderr
         new_stderr = process_char_stream(new_stderr)
     values.append(("text", (new_stdout, new_stderr), []))
+    if new_stderr:
+        new_stdout += "\n" + new_stderr
     syntax = Syntax(
-        f"{new_stdout}\n{new_stderr}",
+        f"{new_stdout}",
         "text",
-        line_numbers=True,  # background_color="default"
+        line_numbers=True,
     )
     segments.append((len(values) - 1, segment[1], syntax))
 

--- a/chat/tests/test_chat_function.py
+++ b/chat/tests/test_chat_function.py
@@ -9,6 +9,8 @@
 
 from og_terminal.terminal_chat import gen_a_random_emoji
 from og_terminal.terminal_chat import parse_numbers
+from og_terminal.terminal_chat import handle_action_end
+from og_proto import agent_server_pb2
 
 
 def test_gen_a_random_emoji():
@@ -20,3 +22,37 @@ def test_parse_number():
     numbers = parse_numbers(test_text)
     assert numbers
     assert numbers[0] == "0"
+
+
+def test_ok_handle_action_end():
+    segments = [(0, "", "")]
+    images = []
+    values = [()]
+    respond = agent_server_pb2.TaskRespond(
+        token_usage=0,
+        iteration=0,
+        respond_type=agent_server_pb2.TaskRespond.OnAgentActionEndType,
+        model_name="",
+        on_agent_action_end=OnAgentActionEnd(
+            output="", output_files=[], has_error=False
+        ),
+    )
+    handle_action_end(segments, respond, images, values)
+    assert segments[0][1] == "✅"
+
+
+def test_error_handle_action_end():
+    segments = [(0, "", "")]
+    images = []
+    values = [()]
+    respond = agent_server_pb2.TaskRespond(
+        token_usage=0,
+        iteration=0,
+        respond_type=agent_server_pb2.TaskRespond.OnAgentActionEndType,
+        model_name="",
+        on_agent_action_end=OnAgentActionEnd(
+            output="", output_files=[], has_error=True
+        ),
+    )
+    handle_action_end(segments, respond, images, values)
+    assert segments[0][1] == "❌"

--- a/chat/tests/test_chat_function.py
+++ b/chat/tests/test_chat_function.py
@@ -33,7 +33,7 @@ def test_ok_handle_action_end():
         iteration=0,
         respond_type=agent_server_pb2.TaskRespond.OnAgentActionEndType,
         model_name="",
-        on_agent_action_end=OnAgentActionEnd(
+        on_agent_action_end=agent_server_pb2.OnAgentActionEnd(
             output="", output_files=[], has_error=False
         ),
     )
@@ -50,7 +50,7 @@ def test_error_handle_action_end():
         iteration=0,
         respond_type=agent_server_pb2.TaskRespond.OnAgentActionEndType,
         model_name="",
-        on_agent_action_end=OnAgentActionEnd(
+        on_agent_action_end=agent_server_pb2.OnAgentActionEnd(
             output="", output_files=[], has_error=True
         ),
     )

--- a/proto/src/og_proto/agent_server.proto
+++ b/proto/src/og_proto/agent_server.proto
@@ -33,6 +33,7 @@ message OnAgentAction {
 message OnAgentActionEnd {
   string output = 1;
   repeated string output_files = 2;
+  bool has_error = 3;
 }
 
 message FinalRespond {

--- a/sdk/tests/agent_sdk_tests.py
+++ b/sdk/tests/agent_sdk_tests.py
@@ -118,6 +118,26 @@ async def test_run_code_test(agent_sdk):
 
 
 @pytest.mark.asyncio
+async def test_run_code_with_error(agent_sdk):
+    sdk = agent_sdk
+    await sdk.add_kernel(api_key, "127.0.0.1:9527")
+    try:
+        responds = []
+        async for respond in sdk.prompt("error function"):
+            responds.append(respond)
+        logger.debug(f"{responds}")
+        assert len(responds) > 0, "no responds for the prompt"
+        assert responds[len(responds) - 2].respond_type == TaskRespond.OnAgentActionEndType
+        assert responds[len(responds) - 2].on_agent_action_end.has_error, "bad has error result"
+        assert responds[len(responds) - 1].respond_type == TaskRespond.OnFinalAnswerType
+        assert (
+            responds[len(responds) - 1].final_respond.answer
+            == "this code prints 'hello world'"
+        )
+    except Exception as ex:
+        assert 0, str(ex)
+
+@pytest.mark.asyncio
 async def test_assemble_test(agent_sdk):
     sdk = agent_sdk
     await sdk.add_kernel(api_key, "127.0.0.1:9527")

--- a/sdk/tests/agent_sdk_tests.py
+++ b/sdk/tests/agent_sdk_tests.py
@@ -127,8 +127,12 @@ async def test_run_code_with_error(agent_sdk):
             responds.append(respond)
         logger.debug(f"{responds}")
         assert len(responds) > 0, "no responds for the prompt"
-        assert responds[len(responds) - 2].respond_type == TaskRespond.OnAgentActionEndType
-        assert responds[len(responds) - 2].on_agent_action_end.has_error, "bad has error result"
+        assert (
+            responds[len(responds) - 2].respond_type == TaskRespond.OnAgentActionEndType
+        )
+        assert responds[
+            len(responds) - 2
+        ].on_agent_action_end.has_error, "bad has error result"
         assert responds[len(responds) - 1].respond_type == TaskRespond.OnFinalAnswerType
         assert (
             responds[len(responds) - 1].final_respond.answer
@@ -136,6 +140,7 @@ async def test_run_code_with_error(agent_sdk):
         )
     except Exception as ex:
         assert 0, str(ex)
+
 
 @pytest.mark.asyncio
 async def test_assemble_test(agent_sdk):

--- a/sdk/tests/agent_sdk_tests.py
+++ b/sdk/tests/agent_sdk_tests.py
@@ -128,10 +128,10 @@ async def test_run_code_with_error(agent_sdk):
         logger.debug(f"{responds}")
         assert len(responds) > 0, "no responds for the prompt"
         assert (
-            responds[len(responds) - 2].respond_type == TaskRespond.OnAgentActionEndType
+            responds[len(responds) - 3].respond_type == TaskRespond.OnAgentActionEndType
         )
         assert responds[
-            len(responds) - 2
+            len(responds) - 3
         ].on_agent_action_end.has_error, "bad has error result"
         assert responds[len(responds) - 1].respond_type == TaskRespond.OnFinalAnswerType
         assert (

--- a/sdk/tests/mock_messages.json
+++ b/sdk/tests/mock_messages.json
@@ -12,6 +12,14 @@
         {
             "explanation": "this code prints 'hello world'"
         }
+    ],
+    "error function":[
+        {
+            "explanation": "this is a hello world code",
+            "code":"print(hello world')"
+        },
+        {
+            "explanation": "this code prints 'hello world'"
+        }
     ]
-
 }

--- a/up/src/og_up/model_downloader.py
+++ b/up/src/og_up/model_downloader.py
@@ -51,4 +51,5 @@ def download(repo, filename, cache_dir, local_dir, socks_proxy):
         cache_dir=real_cache_dir,
         local_dir=real_local_dir,
         proxies=proxies,
+        resume_download=True,
     )

--- a/up/src/og_up/up.py
+++ b/up/src/og_up/up.py
@@ -253,7 +253,7 @@ def choose_api_service(console):
     mk = """Choose your favourite LLM
 1. OpenAI, Kernel, Agent and Cli will be installed
 2. Azure OpenAI, Kernel, Agent and Cli will be installed
-3. Codellama, Model Server, Kernel, Agent and Cli will be installed
+3. Codellama, Llama.cpp Model Server, Kernel, Agent and Cli will be installed
 4. Octogen(beta), Only Cli will be installed
 """
     console.print(Markdown(mk))


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
Adding the ability to handle errors in agent actions.

### Detailed summary:
- Added `has_error` field to `agent_server.proto` message.
- Modified `model_downloader.py` to include `resume_download=True` in the function call.
- Modified `openai_agent.py`, `codellama_agent.py`, and `mock_agent.py` to include `has_error` in the `OnAgentActionEnd` message.
- Modified `up.py` to update the installation instructions.
- Added test cases for handling errors in `agent_sdk_tests.py` and `terminal_chat.py`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->