### PR TITLE
fix: add python path

### DIFF
--- a/docker/start_all.sh
+++ b/docker/start_all.sh
@@ -27,6 +27,8 @@ chown -R octogen:octogen ${ROOT_DIR}/kernel/logs
 chown -R octogen:octogen ${ROOT_DIR}/model_server/logs
 
 cat <<EOF> /bin/start_service.sh
+export PYTHONPATH=/home/octogen/.local/lib/python3.10/site-packages:$PYTHONPATH
+
 if [ "$2" -eq 1 ]
 then
     if [ -z "$3" ]


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding the PYTHONPATH environment variable to the start_service.sh script in the docker/start_all.sh file.

### Detailed summary:
- Added the line `export PYTHONPATH=/home/octogen/.local/lib/python3.10/site-packages:$PYTHONPATH` to the start_service.sh script.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->