### PR TITLE
feat: add proto schema for memory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,8 @@ jobs:
         run: |
           WS_DIR=`pwd`
           bash start_sandbox.sh
+          cd ${WS_DIR}/memory
+          pytest tests/*.py
           cd ${WS_DIR}/agent
           pytest tests/*.py
           cd ${WS_DIR}/sdk

--- a/install_package.sh
+++ b/install_package.sh
@@ -5,6 +5,7 @@
 WORKDIR=`pwd`
 cd ${WORKDIR}/proto && make && pip install .
 cd ${WORKDIR}/sdk && pip install .
+cd ${WORKDIR}/memory && pip install .
 cd ${WORKDIR}/kernel && pip install .
 cd ${WORKDIR}/agent && pip install .
 cd ${WORKDIR}/chat && pip install .

--- a/memory/README.md
+++ b/memory/README.md
@@ -1,0 +1,1 @@
+the memory module for octogen

--- a/memory/setup.py
+++ b/memory/setup.py
@@ -19,15 +19,16 @@ setup(
 
     packages=[
         "og_memory",
+        "og_memory.template",
     ],
 
     package_dir={
         "og_memory": "src/og_memory",
+        "og_memory.template": "src/og_memory/template",
     },
-
     install_requires=[
         "og_proto",
         "Jinja2",
     ],
-    package_data={},
+    package_data={"og_memory.template": ["*.jinja"]},
 )

--- a/memory/setup.py
+++ b/memory/setup.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2023 dbpunk.com Author imotai <codego.me@gmail.com>
+# SPDX-FileCopyrightText: 2023 imotai <jackwang@octogen.dev>
+# SPDX-FileContributor: imotai
+#
+# SPDX-License-Identifier: Elastic-2.0
+
+""" """
+from setuptools import setup, find_packages
+
+setup(
+    name="og_memory",
+    version="0.3.6",
+    description="Open source code interpreter agent",
+    author="imotai",
+    author_email="wangtaize@dbpunk.com",
+    url="https://github.com/dbpunk-labs/octogen",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+
+    packages=[
+        "og_memory",
+    ],
+
+    package_dir={
+        "og_memory": "src/og_memory",
+    },
+
+    install_requires=[
+        "og_proto",
+        "Jinja2",
+    ],
+    package_data={},
+)

--- a/memory/src/og_memory/memory.py
+++ b/memory/src/og_memory/memory.py
@@ -1,0 +1,30 @@
+# vim:fenc=utf-8
+
+# SPDX-FileCopyrightText: 2023 imotai <jackwang@octogen.dev>
+# SPDX-FileContributor: imotai
+#
+# SPDX-License-Identifier: Elastic-2.0
+
+"""
+
+"""
+
+
+# import the agent memory
+from og_proto.memory_pb2 import AgentMemory
+from jinja2 import Environment
+from jinja2.loaders import PackageLoader
+
+env = Environment(loader=PackageLoader("og_memory", "template"))
+context_tpl = env.get_template("agent.jinja")
+
+def agent_memory_to_context(memory: AgentMemory):
+    """
+    Convert the agent memory to context
+    :param memory : AgentMemory
+    :return: string context for llm
+    """
+    return context_tpl.render(prompt=memory.instruction, guides=memory.guide_memory)
+
+
+

--- a/memory/src/og_memory/template/agent.jinja
+++ b/memory/src/og_memory/template/agent.jinja
@@ -1,22 +1,23 @@
 {#the role description#}
 {{prompt.role}}
-
 {#the rule list#}
 {%if prompt.rules%}
-You must follow the below rules
+Follow the rules
 {% for rule in prompt.rules if rule%}
 {{loop.index}}.{{rule}}
 {% endfor%}
 {% endif %}
-
 {%if prompt.actions%}
-You can use the following actions to help you finishing your task
+Use the following actions to help you finishing your task
 {% for action in prompt.actions if action%}
 {{loop.index}}.{{action.name}}: {{action.desc}}
 {% endfor%}
 {% endif %}
-
 {%if guides%}
-Here are the instructions for the tools and libraries you recently used.
-
+The instructions for the tools and libraries you recently used.
+{% for guide in guides if guide%}
+{{loop.index}}.{{guide.name}}
+{{guide.what_it_can_do}}
+{{guide.how_to_use}}
+{% endfor%}
 {% endif %}

--- a/memory/src/og_memory/template/agent.openai.jinja
+++ b/memory/src/og_memory/template/agent.openai.jinja
@@ -1,0 +1,22 @@
+{#the role description#}
+{{prompt.role}}
+
+{#the rule list#}
+{%if prompt.rules%}
+You must follow the below rules
+{% for rule in prompt.rules if rule%}
+{{loop.index}}.{{rule}}
+{% endfor%}
+{% endif %}
+
+{%if prompt.actions%}
+You can use the following actions to help you finishing your task
+{% for action in prompt.actions if action%}
+{{loop.index}}.{{action.name}}: {{action.desc}}
+{% endfor%}
+{% endif %}
+
+{%if guides%}
+Here are the instructions for the tools and libraries you recently used.
+
+{% endif %}

--- a/memory/tests/memory_tests.py
+++ b/memory/tests/memory_tests.py
@@ -1,0 +1,30 @@
+# vim:fenc=utf-8
+
+# SPDX-FileCopyrightText: 2023 imotai <jackwang@octogen.dev>
+# SPDX-FileContributor: imotai
+#
+# SPDX-License-Identifier: Elastic-2.0
+
+"""
+
+"""
+from og_memory.memory import agent_memory_to_context
+from og_proto.memory_pb2 import AgentMemory, ChatMessage, GuideMemory, Feedback
+from og_proto.prompt_pb2 import AgentPrompt, ActionDesc
+# defina a logger variable
+import logging
+logger = logging.getLogger(__name__)
+
+def test_agent_memory_to_context_smoke_test():
+    """
+    test the gent_memory_to_contex for smoke test
+    """
+    action = ActionDesc(name="execute_python_code", desc="run python code")   
+    rules = ["To complete the goal, write a plan and execute it step-by-step, limiting the number of steps to five. the following are examples"]
+    prompt = AgentPrompt(actions=[action], rules=rules, 
+                         role="You are the QA engineer",
+                         role_name="Kitty", output_format="")
+    agent_memory = AgentMemory(instruction=prompt, user_id = "1", user_name="tai", guide_memory=[], chat_memory=[],
+                memory_id="2")
+    context = agent_memory_to_context(agent_memory)
+    logger.info(context)

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -22,6 +22,7 @@ generate: $(PROTOS)
 	@sed -i'' -e 's/import agent_server_pb2 as agent__server__pb2/from . import agent_server_pb2 as agent__server__pb2/' src/og_proto/agent_server_pb2_grpc.py
 	@sed -i'' -e 's/import common_pb2 as common__pb2/from . import common_pb2 as common__pb2/' src/og_proto/agent_server_pb2_grpc.py
 	@sed -i'' -e 's/import common_pb2 as common__pb2/from . import common_pb2 as common__pb2/' src/og_proto/agent_server_pb2.py
+	@sed -i'' -e 's/import prompt_pb2 as prompt__pb2/from . import prompt_pb2 as prompt__pb2/' src/og_proto/memory_pb2.py
 	@echo "'${@}' done"
 
 clean:

--- a/proto/src/og_proto/agent_server.proto
+++ b/proto/src/og_proto/agent_server.proto
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 
 syntax = "proto3";
-package octopus_agent_proto;
+package octogen_agent_proto;
 
 import "common.proto";
 
@@ -141,8 +141,8 @@ service AgentServer {
   // check the connection is ok
   rpc ping(PingRequest) returns (PongResponse) {}
   // upload the file
-  rpc upload(stream octopus_common_proto.FileChunk) returns (octopus_common_proto.FileUploaded) {}
-  rpc download(octopus_common_proto.DownloadRequest) returns (stream octopus_common_proto.FileChunk) {}
+  rpc upload(stream octogen_common_proto.FileChunk) returns (octogen_common_proto.FileUploaded) {}
+  rpc download(octogen_common_proto.DownloadRequest) returns (stream octogen_common_proto.FileChunk) {}
   rpc process_task(ProcessTaskRequest) returns (stream TaskResponse) {}
   rpc add_kernel(AddKernelRequest) returns (AddKernelResponse) {}
 }

--- a/proto/src/og_proto/common.proto
+++ b/proto/src/og_proto/common.proto
@@ -5,7 +5,7 @@
 
 syntax = "proto3";
 
-package octopus_common_proto;
+package octogen_common_proto;
 
 message FileChunk {
   bytes buffer = 1;

--- a/proto/src/og_proto/kernel_server.proto
+++ b/proto/src/og_proto/kernel_server.proto
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 
 syntax = "proto3";
-package octopus_kernel_proto;
+package octogen_kernel_proto;
 
 import "common.proto";
 
@@ -73,6 +73,6 @@ service KernelServerNode {
   rpc stop(StopKernelRequest) returns (StopKernelResponse) {}
   rpc execute(ExecuteRequest) returns (stream ExecuteResponse) {}
   rpc get_status(GetStatusRequest) returns (GetStatusResponse) {}
-  rpc upload(stream octopus_common_proto.FileChunk) returns (octopus_common_proto.FileUploaded) {}
-  rpc download(octopus_common_proto.DownloadRequest) returns (stream octopus_common_proto.FileChunk) {}
+  rpc upload(stream octogen_common_proto.FileChunk) returns (octogen_common_proto.FileUploaded) {}
+  rpc download(octogen_common_proto.DownloadRequest) returns (stream octogen_common_proto.FileChunk) {}
 }

--- a/proto/src/og_proto/memory.proto
+++ b/proto/src/og_proto/memory.proto
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2023 imotai <jackwang@octogen.dev>
+// SPDX-FileContributor: imotai
+//
+// SPDX-License-Identifier: Elastic-2.0
+
+syntax = "proto3";
+package octogen_agent_memory;
+import "prompt.proto";
+
+message GuideMemory {
+    // the name of tool or library
+    string name = 1;
+    // the tool or method of library can solve what kind of problem
+    string what_it_can_do = 2;
+    // how to use the tool or library include how to import and usage
+    string how_to_use = 3;
+    // the timestamp in second
+    int32 recall_time = 4;
+}
+
+message Feedback {
+    bool is_correct = 1;
+    // the timestamp in second
+    int32 feedback_time = 2;
+}
+
+message ChatMessage {
+    // the role name
+    string role_name = 1;
+    // the content of chat message
+    string content = 2;
+    // the function name 
+    string function_name = 3;
+    // the function call content
+    string function_call = 4;
+    // the timestamp in second
+    int32 chat_time = 5;
+    // the feedback of the chat message
+    // and it  will not be sent to LLM
+    Feedback feedback = 6;
+}
+
+// every user has his own memory
+message AgentMemory {
+    octogen_agent_prompt.AgentPrompt instruction = 1;
+    string user_id = 2;
+    string user_name = 3;
+    repeated GuideMemory guide_memory = 4;
+    repeated ChatMessage chat_memory = 5;
+    // reset the memory id to clean the memory
+    string memory_id = 6;
+}

--- a/proto/src/og_proto/prompt.proto
+++ b/proto/src/og_proto/prompt.proto
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2023 imotai <jackwang@octogen.dev>
+// SPDX-FileContributor: imotai
+//
+// SPDX-License-Identifier: Elastic-2.0
+
+syntax = "proto3";
+package octogen_agent_prompt;
+
+message ActionDesc {
+    // the action name
+    string name = 1;
+    // the action description
+    string desc = 2;
+    // the external script for the action
+    string external_script = 3;
+}
+
+message AgentPrompt {
+    // the system role of agent
+    string role = 1;
+    // the rules for the role
+    string rules = 2;
+    repeated ActionDesc actions = 3;
+    // the response format for LLM
+    string output_format = 4;
+    string role_name = 5;
+}

--- a/proto/src/og_proto/prompt.proto
+++ b/proto/src/og_proto/prompt.proto
@@ -19,7 +19,7 @@ message AgentPrompt {
     // the system role of agent
     string role = 1;
     // the rules for the role
-    string rules = 2;
+    repeated string rules = 2;
     repeated ActionDesc actions = 3;
     // the response format for LLM
     string output_format = 4;

--- a/sdk/src/og_sdk/agent_sdk.py
+++ b/sdk/src/og_sdk/agent_sdk.py
@@ -104,6 +104,11 @@ class AgentSyncSDK(AgentBaseSDK):
         for respond in self.stub.process_task(request, metadata=self.metadata):
             yield respond
 
+    def close(self):
+        if self.channel:
+            self.channel.close()
+            self.channel = None
+
 
 class AgentProxySDK(AgentBaseSDK):
 

--- a/sdk/tests/agent_sdk_tests.py
+++ b/sdk/tests/agent_sdk_tests.py
@@ -31,7 +31,6 @@ async def agent_sdk():
     yield sdk
     await sdk.close()
 
-
 def test_connect_bad_endpoint():
     try:
         sdk = AgentSDK("xxx", api_key)
@@ -40,6 +39,18 @@ def test_connect_bad_endpoint():
     except Exception as ex:
         assert 1
 
+
+@pytest.mark.asyncio
+async def test_ping_test_with_bad_kernel_api_key(agent_sdk):
+    """
+    the ping method will throw an exception if the kernel api key is not valid
+    """
+    try:
+        await agent_sdk.add_kernel("bad_kernel_api_key", "127.0.0.1:9527")
+        response = await agent_sdk.ping()
+        assert 0, "should not go here"
+    except Exception as ex:
+        assert 1
 
 @pytest.mark.asyncio
 async def test_ping_test(agent_sdk):

--- a/up/src/og_up/up.py
+++ b/up/src/og_up/up.py
@@ -35,10 +35,12 @@ Welcome = f"""
 Welcome to use {OCTOGEN_TITLE}
 """
 
+
 def random_str(n):
     # generating random strings
     res = "".join(random.choices(string.ascii_uppercase + string.digits, k=n))
     return str(res)
+
 
 def run_install_cli(live, segments):
     """
@@ -66,6 +68,7 @@ def run_install_cli(live, segments):
         segments.append(("❌", "Install octogen terminal cli", outputs))
         refresh(live, segments)
         return False
+
 
 def refresh(
     live,
@@ -441,7 +444,7 @@ def add_kernel_endpoint(live, segments, admin_key, kernel_endpoint, api_key, api
             time.sleep(3)
         except Exception as ex:
             result_code = 1
-            msg = f"connect to {api_base} failed "
+            msg = f"connect to {api_base} failed {ex}"
             time.sleep(3)
     segments.pop()
     if result_code == 0:
@@ -570,7 +573,6 @@ def start_octogen_for_azure_openai(
         segments.append(("❌", "Setup octogen failed", ""))
         refresh(live, segments)
         return False
-
 
 
 def start_octogen_for_codellama(

--- a/up/src/og_up/up.py
+++ b/up/src/og_up/up.py
@@ -572,6 +572,7 @@ def start_octogen_for_azure_openai(
         return False
 
 
+
 def start_octogen_for_codellama(
     live,
     segments,

--- a/up/tests/up_tests.py
+++ b/up/tests/up_tests.py
@@ -171,7 +171,7 @@ def test_start_azure_openai_smoketest():
     kernel_key = random_str(32)
     with Live(Group(*segments), console=console) as live:
         generate_kernel_env(live, segments, install_dir, kernel_key)
-        code = load_docker_image("v0.4.43", "dbpunk/octogen", live, segments)
+        code = load_docker_image("v0.5.1", "dbpunk/octogen", live, segments)
         assert code == 0, "bad result code of loading docker image"
         result = start_octogen_for_azure_openai(
             live,
@@ -181,7 +181,7 @@ def test_start_azure_openai_smoketest():
             admin_key,
             kernel_key,
             "dbpunk/octogen",
-            "v0.4.43",
+            "v0.5.1",
             "azure_open_api_key",
             "test_deployment",
             "https://azure_base",
@@ -200,7 +200,7 @@ def test_start_openai_smoketest():
     kernel_key = random_str(32)
     with Live(Group(*segments), console=console) as live:
         generate_kernel_env(live, segments, install_dir, kernel_key)
-        code = load_docker_image("v0.4.43", "dbpunk/octogen", live, segments)
+        code = load_docker_image("v0.5.1", "dbpunk/octogen", live, segments)
         assert code == 0, "bad result code of loading docker image"
         result = start_octogen_for_openai(
             live,
@@ -210,7 +210,7 @@ def test_start_openai_smoketest():
             admin_key,
             kernel_key,
             "dbpunk/octogen",
-            "v0.4.43",
+            "v0.5.1",
             "openai_api_key",
             "gpt-3.5-turbo",
         )
@@ -227,7 +227,7 @@ def test_start_codellama_smoketest():
     kernel_key = random_str(32)
     with Live(Group(*segments), console=console) as live:
         generate_kernel_env(live, segments, install_dir, kernel_key)
-        code = load_docker_image("v0.4.43", "dbpunk/octogen", live, segments)
+        code = load_docker_image("v0.5.1", "dbpunk/octogen", live, segments)
         assert code == 0, "bad result code of loading docker image"
         result = start_octogen_for_codellama(
             live,
@@ -239,7 +239,7 @@ def test_start_codellama_smoketest():
             admin_key,
             kernel_key,
             "dbpunk/octogen",
-            "v0.4.43",
+            "v0.5.1",
         )
         assert result
 
@@ -258,5 +258,5 @@ def test_load_valid_docker_image():
     console = Console()
     segments = []
     with Live(Group(*segments), console=console) as live:
-        code = load_docker_image("v0.4.43", "dbpunk/octogen", live, segments)
+        code = load_docker_image("v0.5.1", "dbpunk/octogen", live, segments)
         assert code == 0, "loading image should be ok"


### PR DESCRIPTION
## The Focus

- Support context in v0.6.0.
- Improving the accuracy of model-generated code and tool commands using external vector storage

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the memory module for octogen. 

### Detailed summary:
- Updated the memory module for octogen
- Changed the package name from octopus_common_proto to octogen_common_proto
- Added a new module for agent memory in og_memory
- Added new proto files for agent and kernel servers
- Updated the setup.py file for og_memory
- Added new tests for agent memory and agent SDK

> The following files were skipped due to too many changes: `up/tests/up_tests.py`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->