### PR TITLE
fix: remove windoa and mac env

### DIFF
--- a/.github/workflows/cli_ci.yaml
+++ b/.github/workflows/cli_ci.yaml
@@ -11,7 +11,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        #os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: ["3.11"]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the CI workflow file `cli_ci.yaml` by modifying the `os` and `python-version` matrix options. 

### Detailed summary:
- Removed `windows-latest` and `macos-latest` from the `os` matrix option.
- Updated `python-version` to `"3.11"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->